### PR TITLE
Fixed: reset the skip_section flag

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -77,7 +77,7 @@ for line in docbook:
 
     if skip_section:
         if line.strip().find('</sect1>') != -1:
-            skip_section = True
+            skip_section = False
         continue
 
     if line.strip().find('<informaltable frame="all">') != -1:


### PR DESCRIPTION
Once we reach the end of a skiped section, the skip_section flag needs to be reset to False.